### PR TITLE
feat: add `bulkyard schema` command and core schema utilities

### DIFF
--- a/messages/bulkyard.extract.md
+++ b/messages/bulkyard.extract.md
@@ -18,6 +18,10 @@ Alternatively, use --sobject and --query to extract a single object without a co
 
   <%= config.bin %> <%= command.id %> --target-org myOrg --sobject Account --query "SELECT Id, Name FROM Account"
 
+- Extract all fields from an object using SELECT \*:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg -s Account -q "SELECT \* FROM Account"
+
 - Extract inline with a custom database and table name:
 
   <%= config.bin %> <%= command.id %> --target-org myOrg -s Account -q "SELECT Id, Name FROM Account" -d my.db -t Account_Backup
@@ -49,6 +53,10 @@ Extracting %s...
 # info.complete
 
 Extraction complete.
+
+# prompt.cacheSchema
+
+Schema for "%s" was fetched from the org. Save it locally for future extractions? (y/N)
 
 # error.objectFailed
 

--- a/messages/bulkyard.schema.md
+++ b/messages/bulkyard.schema.md
@@ -1,0 +1,39 @@
+# summary
+
+Cache Salesforce object schemas into a local SQLite database.
+
+# description
+
+Describes one or more Salesforce objects and caches their field metadata into a local SQLite database. Cached schemas allow `bulkyard extract` to expand `SELECT *` queries without making a live describe call.
+
+Provide object names via `--sobjects` (comma-separated) or read them from a `--config-file`.
+
+# examples
+
+- Cache schemas for specific objects:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg --sobjects Account,Contact
+
+- Cache schemas for all objects in a config file:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg --config-file bulkyard.config.yml
+
+# flags.sobjects.summary
+
+Comma-separated list of Salesforce object API names to describe.
+
+# flags.config-file.summary
+
+Path to the YAML config file (reads object names from it).
+
+# flags.database.summary
+
+Path to the SQLite database file.
+
+# info.describing
+
+Describing %s...
+
+# info.complete
+
+Schema caching complete.

--- a/plans/select-star-expansion.md
+++ b/plans/select-star-expansion.md
@@ -1,0 +1,171 @@
+# Plan: SELECT \* Expansion and Schema Command
+
+## Context
+
+Salesforce Bulk API 2.0 does not support `SELECT *` in SOQL. Users currently must enumerate every field explicitly. This change lets users write `SELECT * FROM Account WHERE ...` and have bulkyard expand `*` into all queryable field names before submitting the query. A new `sf bulkyard schema` command caches object metadata into the SQLite database so repeated extracts skip the live `conn.describe()` call.
+
+## Development Approach: TDD
+
+Each phase follows red-green-refactor. Write tests first, verify they fail, then implement until they pass.
+
+## Phase 1: Core Schema Module
+
+**1a. Write tests first: `test/core/schema.test.ts`**
+
+Test cases for each function before any implementation:
+
+- `containsSelectStar`: true for `SELECT * FROM Account`, `select * from Account WHERE ...`; false for `SELECT Id FROM Account`
+- `extractObjectName`: returns `Account` from `SELECT * FROM Account WHERE ...`; throws on malformed query
+- `getQueryableFields`: excludes fields with type `address` or `location`
+- `expandSelectStar`: replaces `*` with field names, preserves WHERE/ORDER BY/LIMIT
+- `describeToFieldInfos`: maps describe fields to `CachedFieldInfo[]`
+
+**1b. Write tests: `test/core/database.test.ts`** (extend existing)
+
+- `createSchemaTable` creates the table
+- `writeSchema` + `readSchema` round-trip
+- `readSchema` returns null for uncached objects
+- `writeSchema` replaces existing rows on re-write
+
+**1c. Implement `src/core/schema.ts`** — make tests green
+
+**1d. Implement schema methods in `src/core/database.ts`** — make tests green
+
+**Create `src/core/schema.ts`**
+
+Types:
+
+- `CachedFieldInfo` — `{ name: string; type: string }` (minimal per-field metadata)
+
+Functions:
+
+- `containsSelectStar(query: string): boolean` — regex test for `SELECT * FROM`
+- `extractObjectName(query: string): string` — extracts object name from `FROM <object>`
+- `getQueryableFields(fields: CachedFieldInfo[]): CachedFieldInfo[]` — filters out compound types (`address`, `location`)
+- `expandSelectStar(query: string, fields: CachedFieldInfo[]): string` — replaces `SELECT * FROM` with `SELECT field1, field2, ... FROM`, preserving WHERE/ORDER BY/LIMIT
+- `describeToFieldInfos(describeResult): CachedFieldInfo[]` — maps describe fields to cache format
+
+Schema cache stored in SQLite via `BulkyardDatabase`:
+
+- `readSchemaCache(db: BulkyardDatabase, objectName: string): CachedFieldInfo[] | null`
+- `writeSchemaCache(db: BulkyardDatabase, objectName: string, fields: CachedFieldInfo[]): void`
+
+The cache table `_bulkyard_schema` has columns: `object_name TEXT`, `field_name TEXT`, `field_type TEXT`. The underscore prefix distinguishes it from data tables. `writeSchemaCache` drops-and-recreates rows for the given object (upsert-by-delete pattern matching `createTable`).
+
+## Phase 2: Schema Command
+
+**2a. Write tests first: `test/commands/bulkyard/schema.test.ts`**
+
+- Command metadata: summary, description, examples defined
+- Flag definitions: `--sobjects`, `--config-file`, `--database`, `--target-org`
+- Run logic: stubs `conn.describe()`, verifies `writeSchema` is called for each object
+
+**2b. Implement `src/commands/bulkyard/schema.ts`** — make tests green
+
+**Create `src/commands/bulkyard/schema.ts`**
+
+```
+sf bulkyard schema --target-org myOrg --sobjects Account,Contact
+sf bulkyard schema --target-org myOrg --config-file bulkyard.config.yml
+```
+
+Flags:
+
+- `--target-org` (required) — org to describe
+- `--api-version` (optional)
+- `--sobjects` (string) — comma-separated list of object API names; `exactlyOne` with `--config-file`
+- `--config-file` (file) — reads object names from existing bulkyard YAML config
+- `--database` (string, default `bulkyard.db`) — SQLite database to write schema cache to; `exclusive` with `--config-file` (config file provides its own database path)
+
+Logic:
+
+1. Determine object list from `--sobjects` (split on comma, trim) or config file
+2. Open SQLite database
+3. For each object, call `conn.describe(objectName)`
+4. Map to `CachedFieldInfo[]` via `describeToFieldInfos()`
+5. Write to `_bulkyard_schema` table via `writeSchemaCache()`
+6. Log summary table: object name, field count
+
+Return type: `{ database: string; objects: string[] }`
+
+**Create `messages/bulkyard.schema.md`** — command messages
+
+**Create `test/commands/bulkyard/schema.test.ts`** — command tests
+
+## Phase 3: Extract Integration
+
+**3a. Write tests first: extend `test/core/extractor.test.ts`**
+
+- `extractObject` with `SELECT * FROM Account` expands to explicit fields (verify `requestPost` stub receives expanded query)
+- When `_bulkyard_schema` has cached fields, no `conn.describe()` call is made
+- When cache miss, falls back to `conn.describe()`
+- Compound fields excluded from expansion
+- Return value indicates whether live describe was used
+
+**3b. Write tests first: extend `test/commands/bulkyard/extract.test.ts`**
+
+- After SELECT \* with cache miss, `confirm` prompt is called
+- If user confirms, `writeSchema` is called
+- If user declines, no schema written
+
+**3c. Implement changes** — make tests green
+
+**Modify `src/core/extractor.ts`**
+
+Add a `resolveQuery` function (or inline in `extractObject`) that handles SELECT \* expansion:
+
+1. If `containsSelectStar(query)` is true:
+   - Try loading fields from `_bulkyard_schema` table for `objConfig.object`
+   - If cache miss, fall back to `conn.describe()` and convert via `describeToFieldInfos()`
+   - Call `expandSelectStar(query, getQueryableFields(fields))` to get the expanded query
+   - Reuse the resolved fields for the `fieldMap` (avoid redundant describe call)
+   - Return a flag indicating the schema was fetched live (not from cache)
+2. If query does NOT contain `SELECT *`: existing flow unchanged
+
+**Modify `src/core/database.ts`**
+
+Add methods to support the schema cache table:
+
+- `createSchemaTable(): void` — creates `_bulkyard_schema` if not exists
+- `readSchema(objectName: string): Array<{ field_name: string; field_type: string }> | null` — returns rows or null if none
+- `writeSchema(objectName: string, fields: Array<{ field_name: string; field_type: string }>): void` — deletes existing rows for object, inserts new ones
+
+**Modify `src/commands/bulkyard/extract.ts`**
+
+After a successful SELECT \* extraction where the schema was fetched live (not from cache), prompt the user:
+
+```
+Schema for "Account" was fetched from the org. Save it locally for future extractions? (y/N)
+```
+
+Uses `this.confirm({ message, defaultAnswer: false })` from `SfCommand`. If confirmed, calls `writeSchemaCache()` to persist to `_bulkyard_schema`. This keeps the extractor pure (no I/O prompts) and puts the interactive logic in the command layer where it belongs.
+
+To support this, `extractObject` returns additional metadata indicating which objects had a live describe (cache miss) so the command can prompt accordingly.
+
+**Modify `messages/bulkyard.extract.md`** — add SELECT \* example and confirm prompt message
+
+**Update `test/core/extractor.test.ts`** — test SELECT \* expansion, cache hit/miss, compound field exclusion
+
+## Files Summary
+
+| Action | File                                                                        |
+| ------ | --------------------------------------------------------------------------- |
+| Create | `src/core/schema.ts`                                                        |
+| Create | `src/commands/bulkyard/schema.ts`                                           |
+| Create | `messages/bulkyard.schema.md`                                               |
+| Create | `test/core/schema.test.ts`                                                  |
+| Create | `test/commands/bulkyard/schema.test.ts`                                     |
+| Modify | `src/core/database.ts` — add schema table methods                           |
+| Modify | `src/core/extractor.ts` — SELECT \* expansion before Bulk API job           |
+| Modify | `src/commands/bulkyard/extract.ts` — prompt to persist schema on cache miss |
+| Modify | `messages/bulkyard.extract.md` — SELECT \* example, confirm prompt message  |
+| Modify | `test/core/extractor.test.ts` — SELECT \* expansion tests                   |
+| Modify | `test/core/database.test.ts` — schema table method tests                    |
+
+## Verification
+
+1. `yarn test:only` — all existing and new unit tests pass
+2. `yarn compile` — TypeScript compiles cleanly
+3. `yarn lint` — no lint errors
+4. Manual: `sf bulkyard schema -o myOrg --sobjects Account,Contact` populates `_bulkyard_schema` in `bulkyard.db`
+5. Manual: `sf bulkyard extract -o myOrg -s Account -q "SELECT * FROM Account"` expands and extracts all queryable fields

--- a/src/commands/bulkyard/extract.ts
+++ b/src/commands/bulkyard/extract.ts
@@ -72,6 +72,22 @@ export default class Extract extends SfCommand<ExtractCommandResult> {
 
         if (result.success) {
           this.log(`  ${result.object} -> ${result.table}: ${result.recordCount} records`);
+
+          // Prompt to cache schema when a live describe was used (SELECT * cache miss)
+          if (result.liveDescribe && result.liveDescribeFields) {
+            // eslint-disable-next-line no-await-in-loop
+            const shouldCache = await this.confirm({
+              message: messages.getMessage('prompt.cacheSchema', [result.object]),
+              defaultAnswer: false,
+            });
+            if (shouldCache) {
+              db.createSchemaTable();
+              db.writeSchema(
+                result.object,
+                result.liveDescribeFields.map((f) => ({ fieldName: f.name, fieldType: f.type }))
+              );
+            }
+          }
         } else {
           this.warn(messages.getMessage('error.objectFailed', [result.object, result.error ?? 'unknown']));
         }

--- a/src/commands/bulkyard/schema.ts
+++ b/src/commands/bulkyard/schema.ts
@@ -1,0 +1,85 @@
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+import { loadConfig } from '../../core/config.js';
+import { BulkyardDatabase } from '../../core/database.js';
+import { describeToFieldInfos } from '../../core/schema.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('bulkyard', 'bulkyard.schema');
+
+/** Return type for the `bulkyard schema` command. */
+export type SchemaCommandResult = { database: string; objects: string[] };
+
+export default class Schema extends SfCommand<SchemaCommandResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    sobjects: Flags.string({
+      summary: messages.getMessage('flags.sobjects.summary'),
+      exactlyOne: ['sobjects', 'config-file'],
+    }),
+    'config-file': Flags.file({
+      char: 'c',
+      summary: messages.getMessage('flags.config-file.summary'),
+      exists: true,
+      exactlyOne: ['sobjects', 'config-file'],
+    }),
+    database: Flags.string({
+      char: 'd',
+      summary: messages.getMessage('flags.database.summary'),
+      default: 'bulkyard.db',
+      exclusive: ['config-file'],
+    }),
+  };
+
+  public async run(): Promise<SchemaCommandResult> {
+    const { flags } = await this.parse(Schema);
+
+    let objectNames: string[];
+    let dbPath: string;
+
+    if (flags['config-file']) {
+      const config = loadConfig(flags['config-file']);
+      objectNames = config.objects.map((o) => o.object);
+      dbPath = config.database;
+    } else {
+      objectNames = flags.sobjects!.split(',').map((s) => s.trim());
+      dbPath = flags.database!;
+    }
+
+    const conn = flags['target-org'].getConnection(flags['api-version']);
+    const db = new BulkyardDatabase(dbPath);
+
+    try {
+      db.createSchemaTable();
+
+      for (const objectName of objectNames) {
+        this.spinner.start(messages.getMessage('info.describing', [objectName]));
+        // eslint-disable-next-line no-await-in-loop
+        const describeResult = await conn.describe(objectName);
+        const fieldInfos = describeToFieldInfos(describeResult);
+        db.writeSchema(
+          objectName,
+          fieldInfos.map((f) => ({ fieldName: f.name, fieldType: f.type }))
+        );
+        this.spinner.stop();
+        this.log(`  ${objectName}: ${fieldInfos.length} fields cached`);
+      }
+
+      this.log(messages.getMessage('info.complete'));
+      this.styledHeader('Schema Cache Results');
+      this.table({
+        data: objectNames.map((name) => ({ object: name })) as unknown as Array<Record<string, unknown>>,
+        columns: ['object'],
+      });
+    } finally {
+      db.close();
+    }
+
+    return { database: dbPath, objects: objectNames };
+  }
+}

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -78,6 +78,37 @@ export class BulkyardDatabase {
     return row.cnt;
   }
 
+  public createSchemaTable(): void {
+    this.db.exec(`CREATE TABLE IF NOT EXISTS "_bulkyard_schema" (
+      object_name TEXT NOT NULL,
+      field_name TEXT NOT NULL,
+      field_type TEXT NOT NULL
+    )`);
+  }
+
+  public readSchema(objectName: string): Array<{ fieldName: string; fieldType: string }> | null {
+    const rows = this.db
+      .prepare('SELECT field_name, field_type FROM "_bulkyard_schema" WHERE object_name = ?')
+      .all(objectName) as Array<{ field_name: string; field_type: string }>;
+    if (rows.length === 0) return null;
+    return rows.map((r) => ({ fieldName: r.field_name, fieldType: r.field_type }));
+  }
+
+  public writeSchema(objectName: string, fields: Array<{ fieldName: string; fieldType: string }>): void {
+    this.createSchemaTable();
+    const deleteStmt = this.db.prepare('DELETE FROM "_bulkyard_schema" WHERE object_name = ?');
+    const insertStmt = this.db.prepare(
+      'INSERT INTO "_bulkyard_schema" (object_name, field_name, field_type) VALUES (?, ?, ?)'
+    );
+
+    this.db.transaction(() => {
+      deleteStmt.run(objectName);
+      for (const f of fields) {
+        insertStmt.run(objectName, f.fieldName, f.fieldType);
+      }
+    })();
+  }
+
   public close(): void {
     this.db.close();
   }

--- a/src/core/extractor.ts
+++ b/src/core/extractor.ts
@@ -2,6 +2,13 @@ import { Connection } from '@salesforce/core';
 import { parse } from 'csv-parse/sync';
 import { BulkyardDatabase, ColumnDef } from './database.js';
 import { BulkyardObjectConfig } from './config.js';
+import {
+  containsSelectStar,
+  expandSelectStar,
+  getQueryableFields,
+  describeToFieldInfos,
+  CachedFieldInfo,
+} from './schema.js';
 
 /** Result of extracting a single Salesforce object into SQLite. */
 export type ExtractResult = {
@@ -15,6 +22,10 @@ export type ExtractResult = {
   success: boolean;
   /** Error message if the extraction failed. */
   error?: string;
+  /** Whether a live describe call was made (cache miss) for SELECT * expansion. */
+  liveDescribe?: boolean;
+  /** Field infos fetched via live describe, available for caching. */
+  liveDescribeFields?: CachedFieldInfo[];
 };
 
 const BATCH_SIZE = 1000;
@@ -58,13 +69,39 @@ export async function extractObject(
     const apiVersion = conn.getApiVersion();
     const jobsUrl = `${conn.instanceUrl}/services/data/v${apiVersion}/jobs/query`;
 
-    const describeResult = await conn.describe(objConfig.object);
-    const fieldMap = new Map(describeResult.fields.map((f) => [f.name, f.type]));
+    let resolvedQuery = objConfig.query!;
+    let fieldMap: Map<string, string>;
+    let liveDescribe = false;
+    let liveDescribeFields: CachedFieldInfo[] | undefined;
+
+    if (containsSelectStar(resolvedQuery)) {
+      // Try schema cache first
+      db.createSchemaTable();
+      const cached = db.readSchema(objConfig.object);
+      let allFields: CachedFieldInfo[];
+
+      if (cached) {
+        allFields = cached.map((r) => ({ name: r.fieldName, type: r.fieldType }));
+      } else {
+        // Cache miss — fall back to live describe
+        const describeResult = await conn.describe(objConfig.object);
+        allFields = describeToFieldInfos(describeResult);
+        liveDescribe = true;
+        liveDescribeFields = allFields;
+      }
+
+      const queryableFields = getQueryableFields(allFields);
+      resolvedQuery = expandSelectStar(resolvedQuery, queryableFields);
+      fieldMap = new Map(allFields.map((f) => [f.name, f.type]));
+    } else {
+      const describeResult = await conn.describe(objConfig.object);
+      fieldMap = new Map(describeResult.fields.map((f) => [f.name, f.type]));
+    }
 
     // Create the bulk query job
     const jobInfo = await conn.requestPost<QueryJobInfo>(jobsUrl, {
       operation: 'query',
-      query: objConfig.query,
+      query: resolvedQuery,
     });
 
     // Poll until the job is complete
@@ -128,7 +165,14 @@ export async function extractObject(
       db.insertRecords(tableName, recordKeys, buffer);
     }
 
-    return { object: objConfig.object, table: tableName, recordCount: totalCount, success: true };
+    return {
+      object: objConfig.object,
+      table: tableName,
+      recordCount: totalCount,
+      success: true,
+      liveDescribe,
+      liveDescribeFields,
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { object: objConfig.object, table: tableName, recordCount: 0, success: false, error: message };

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,0 +1,45 @@
+/** Minimal per-field metadata stored in the schema cache. */
+export type CachedFieldInfo = {
+  /** The field API name. */
+  name: string;
+  /** The Salesforce field type (e.g. "string", "id", "boolean"). */
+  type: string;
+};
+
+const SELECT_STAR_RE = /\bSELECT\s+\*\s+FROM\b/i;
+const FROM_OBJECT_RE = /\bFROM\s+(\w+)/i;
+
+/** Compound field types that cannot be queried directly in SOQL. */
+const COMPOUND_TYPES = new Set(['address', 'location']);
+
+/** Returns true if the query contains `SELECT * FROM`. */
+export function containsSelectStar(query: string): boolean {
+  return SELECT_STAR_RE.test(query);
+}
+
+/** Extracts the object name from the `FROM <object>` clause of a SOQL query. */
+export function extractObjectName(query: string): string {
+  const match = FROM_OBJECT_RE.exec(query);
+  if (!match) {
+    throw new Error(`Unable to extract object name from query: ${query}`);
+  }
+  return match[1];
+}
+
+/** Filters out compound field types that cannot be queried directly. */
+export function getQueryableFields(fields: CachedFieldInfo[]): CachedFieldInfo[] {
+  return fields.filter((f) => !COMPOUND_TYPES.has(f.type));
+}
+
+/** Replaces `SELECT * FROM` with an explicit field list, preserving the rest of the query. */
+export function expandSelectStar(query: string, fields: CachedFieldInfo[]): string {
+  const fieldList = fields.map((f) => f.name).join(', ');
+  return query.replace(SELECT_STAR_RE, `SELECT ${fieldList} FROM`);
+}
+
+/** Maps a Salesforce describe result's fields array to CachedFieldInfo[]. */
+export function describeToFieldInfos(describeResult: {
+  fields: Array<{ name: string; type: string }>;
+}): CachedFieldInfo[] {
+  return describeResult.fields.map((f) => ({ name: f.name, type: f.type }));
+}

--- a/test/commands/bulkyard/schema.test.ts
+++ b/test/commands/bulkyard/schema.test.ts
@@ -1,0 +1,36 @@
+import { TestContext } from '@salesforce/core/testSetup';
+import { expect } from 'chai';
+import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import Schema from '../../../src/commands/bulkyard/schema.js';
+
+describe('bulkyard schema', () => {
+  const $$ = new TestContext();
+
+  beforeEach(() => {
+    stubSfCommandUx($$.SANDBOX);
+  });
+
+  afterEach(() => {
+    $$.restore();
+  });
+
+  it('defines expected flags', () => {
+    expect(Schema.flags).to.have.property('target-org');
+    expect(Schema.flags).to.have.property('api-version');
+    expect(Schema.flags).to.have.property('sobjects');
+    expect(Schema.flags).to.have.property('config-file');
+    expect(Schema.flags).to.have.property('database');
+  });
+
+  it('has a summary', () => {
+    expect(Schema.summary).to.be.a('string').and.not.empty;
+  });
+
+  it('has a description', () => {
+    expect(Schema.description).to.be.a('string').and.not.empty;
+  });
+
+  it('has examples', () => {
+    expect(Schema.examples).to.be.an('array').with.length.greaterThan(0);
+  });
+});

--- a/test/core/database.test.ts
+++ b/test/core/database.test.ts
@@ -103,4 +103,46 @@ describe('BulkyardDatabase', () => {
       expect(db.getRowCount('Empty')).to.equal(0);
     });
   });
+
+  describe('createSchemaTable', () => {
+    it('creates the _bulkyard_schema table', () => {
+      db.createSchemaTable();
+      expect(db.tableExists('_bulkyard_schema')).to.be.true;
+    });
+
+    it('is idempotent', () => {
+      db.createSchemaTable();
+      db.createSchemaTable();
+      expect(db.tableExists('_bulkyard_schema')).to.be.true;
+    });
+  });
+
+  describe('writeSchema + readSchema', () => {
+    it('round-trips field data', () => {
+      db.createSchemaTable();
+      const fields = [
+        { fieldName: 'Id', fieldType: 'id' },
+        { fieldName: 'Name', fieldType: 'string' },
+      ];
+      db.writeSchema('Account', fields);
+      const result = db.readSchema('Account');
+      expect(result).to.deep.equal(fields);
+    });
+
+    it('returns null for uncached objects', () => {
+      db.createSchemaTable();
+      expect(db.readSchema('NotCached')).to.be.null;
+    });
+
+    it('replaces existing rows on re-write', () => {
+      db.createSchemaTable();
+      db.writeSchema('Account', [{ fieldName: 'Id', fieldType: 'id' }]);
+      db.writeSchema('Account', [
+        { fieldName: 'Id', fieldType: 'id' },
+        { fieldName: 'Name', fieldType: 'string' },
+      ]);
+      const result = db.readSchema('Account');
+      expect(result).to.have.lengthOf(2);
+    });
+  });
 });

--- a/test/core/extractor.test.ts
+++ b/test/core/extractor.test.ts
@@ -180,6 +180,103 @@ describe('extractObject', () => {
     expect(result.error).to.include('500');
   });
 
+  describe('SELECT * expansion', () => {
+    it('expands SELECT * to explicit fields using live describe on cache miss', async () => {
+      const describeStub = sinon.stub().resolves({
+        fields: [
+          { name: 'Id', type: 'id' },
+          { name: 'Name', type: 'string' },
+          { name: 'BillingAddress', type: 'address' },
+        ],
+      });
+      const requestPostStub = sinon.stub().resolves({ id: 'job-123', state: 'UploadComplete' });
+      const conn = makeConn({ describe: describeStub, requestPost: requestPostStub });
+      fetchStub.resolves({
+        ok: true,
+        headers: new Headers({ 'sforce-locator': 'null' }),
+        text: async () => 'Id,Name\n001,Acme\n',
+      });
+
+      const result = await extractObject(conn as never, db, {
+        object: 'Account',
+        query: 'SELECT * FROM Account',
+      });
+
+      expect(result.success).to.be.true;
+      expect(result.liveDescribe).to.be.true;
+      expect(result.liveDescribeFields).to.deep.equal([
+        { name: 'Id', type: 'id' },
+        { name: 'Name', type: 'string' },
+        { name: 'BillingAddress', type: 'address' },
+      ]);
+
+      // Verify the expanded query was sent (no address field, no *)
+      const postedQuery = (requestPostStub.firstCall.args[1] as Record<string, unknown>).query as string;
+      expect(postedQuery).to.include('Id');
+      expect(postedQuery).to.include('Name');
+      expect(postedQuery).to.not.include('*');
+      expect(postedQuery).to.not.include('BillingAddress');
+    });
+
+    it('uses cached schema when available (no live describe)', async () => {
+      // Pre-populate schema cache
+      db.createSchemaTable();
+      db.writeSchema('Account', [
+        { fieldName: 'Id', fieldType: 'id' },
+        { fieldName: 'Name', fieldType: 'string' },
+      ]);
+
+      const describeStub = sinon.stub().resolves({ fields: [] });
+      const requestPostStub = sinon.stub().resolves({ id: 'job-123', state: 'UploadComplete' });
+      const conn = makeConn({ describe: describeStub, requestPost: requestPostStub });
+      fetchStub.resolves({
+        ok: true,
+        headers: new Headers({ 'sforce-locator': 'null' }),
+        text: async () => 'Id,Name\n001,Acme\n',
+      });
+
+      const result = await extractObject(conn as never, db, {
+        object: 'Account',
+        query: 'SELECT * FROM Account',
+      });
+
+      expect(result.success).to.be.true;
+      expect(result.liveDescribe).to.be.false;
+      expect(describeStub.called).to.be.false;
+
+      const postedQuery = (requestPostStub.firstCall.args[1] as Record<string, unknown>).query as string;
+      expect(postedQuery).to.equal('SELECT Id, Name FROM Account');
+    });
+
+    it('excludes compound fields from expansion', async () => {
+      const requestPostStub = sinon.stub().resolves({ id: 'job-123', state: 'UploadComplete' });
+      const conn = makeConn({
+        describe: sinon.stub().resolves({
+          fields: [
+            { name: 'Id', type: 'id' },
+            { name: 'Geo__c', type: 'location' },
+            { name: 'Address', type: 'address' },
+          ],
+        }),
+        requestPost: requestPostStub,
+      });
+      fetchStub.resolves({
+        ok: true,
+        headers: new Headers({ 'sforce-locator': 'null' }),
+        text: async () => 'Id\n001\n',
+      });
+
+      const result = await extractObject(conn as never, db, {
+        object: 'Account',
+        query: 'SELECT * FROM Account',
+      });
+
+      expect(result.success).to.be.true;
+      const postedQuery = (requestPostStub.firstCall.args[1] as Record<string, unknown>).query as string;
+      expect(postedQuery).to.equal('SELECT Id FROM Account');
+    });
+  });
+
   it('converts empty CSV values to null', async () => {
     const conn = makeConn({
       describe: sinon.stub().resolves({

--- a/test/core/schema.test.ts
+++ b/test/core/schema.test.ts
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import {
+  containsSelectStar,
+  extractObjectName,
+  getQueryableFields,
+  expandSelectStar,
+  describeToFieldInfos,
+  CachedFieldInfo,
+} from '../../src/core/schema.js';
+
+describe('schema', () => {
+  describe('containsSelectStar', () => {
+    it('returns true for SELECT * FROM Account', () => {
+      expect(containsSelectStar('SELECT * FROM Account')).to.be.true;
+    });
+
+    it('returns true for lowercase select * from', () => {
+      expect(containsSelectStar('select * from Account WHERE Name != null')).to.be.true;
+    });
+
+    it('returns false for SELECT Id FROM Account', () => {
+      expect(containsSelectStar('SELECT Id FROM Account')).to.be.false;
+    });
+
+    it('returns false for SELECT Id, Name FROM Account', () => {
+      expect(containsSelectStar('SELECT Id, Name FROM Account')).to.be.false;
+    });
+  });
+
+  describe('extractObjectName', () => {
+    it('extracts Account from SELECT * FROM Account', () => {
+      expect(extractObjectName('SELECT * FROM Account')).to.equal('Account');
+    });
+
+    it('extracts object name with WHERE clause', () => {
+      expect(extractObjectName('SELECT * FROM Contact WHERE Email != null')).to.equal('Contact');
+    });
+
+    it('throws on malformed query without FROM', () => {
+      expect(() => extractObjectName('SELECT *')).to.throw('Unable to extract object name');
+    });
+  });
+
+  describe('getQueryableFields', () => {
+    it('excludes address and location fields', () => {
+      const fields: CachedFieldInfo[] = [
+        { name: 'Id', type: 'id' },
+        { name: 'Name', type: 'string' },
+        { name: 'BillingAddress', type: 'address' },
+        { name: 'Geolocation__c', type: 'location' },
+      ];
+      const result = getQueryableFields(fields);
+      expect(result).to.deep.equal([
+        { name: 'Id', type: 'id' },
+        { name: 'Name', type: 'string' },
+      ]);
+    });
+
+    it('returns all fields when none are compound', () => {
+      const fields: CachedFieldInfo[] = [
+        { name: 'Id', type: 'id' },
+        { name: 'Name', type: 'string' },
+      ];
+      expect(getQueryableFields(fields)).to.deep.equal(fields);
+    });
+  });
+
+  describe('expandSelectStar', () => {
+    it('replaces * with field names', () => {
+      const fields: CachedFieldInfo[] = [
+        { name: 'Id', type: 'id' },
+        { name: 'Name', type: 'string' },
+      ];
+      expect(expandSelectStar('SELECT * FROM Account', fields)).to.equal('SELECT Id, Name FROM Account');
+    });
+
+    it('preserves WHERE clause', () => {
+      const fields: CachedFieldInfo[] = [{ name: 'Id', type: 'id' }];
+      expect(expandSelectStar('SELECT * FROM Account WHERE Name != null', fields)).to.equal(
+        'SELECT Id FROM Account WHERE Name != null'
+      );
+    });
+
+    it('preserves ORDER BY and LIMIT', () => {
+      const fields: CachedFieldInfo[] = [
+        { name: 'Id', type: 'id' },
+        { name: 'Name', type: 'string' },
+      ];
+      expect(expandSelectStar('SELECT * FROM Account ORDER BY Name LIMIT 10', fields)).to.equal(
+        'SELECT Id, Name FROM Account ORDER BY Name LIMIT 10'
+      );
+    });
+  });
+
+  describe('describeToFieldInfos', () => {
+    it('maps describe fields to CachedFieldInfo[]', () => {
+      const describeResult = {
+        fields: [
+          { name: 'Id', type: 'id', label: 'Record ID', length: 18 },
+          { name: 'Name', type: 'string', label: 'Name', length: 255 },
+        ],
+      };
+      const result = describeToFieldInfos(describeResult);
+      expect(result).to.deep.equal([
+        { name: 'Id', type: 'id' },
+        { name: 'Name', type: 'string' },
+      ]);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@salesforce/dev-config/tsconfig-strict-esm",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,7 +1285,7 @@
 
 "@oclif/plugin-command-snapshot@^5.3.9":
   version "5.3.9"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-command-snapshot/-/plugin-command-snapshot-5.3.9.tgz#a687cd53c17e1faeb8381a0b46121f498e4f09b5"
+  resolved "https://registry.npmjs.org/@oclif/plugin-command-snapshot/-/plugin-command-snapshot-5.3.9.tgz"
   integrity sha512-1l/uOKbRefdRQzyOLwqlOq+CUtvuqFNnEi8c7vYEE3eCnlSk3th2LZXoC/Na3y8eIEJU1mhEa6FX8UumCcVzzg==
   dependencies:
     "@oclif/core" "^4"
@@ -2075,7 +2075,7 @@
 
 "@types/better-sqlite3@^7.6.13":
   version "7.6.13"
-  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz#a72387f00d2f53cab699e63f2e2c05453cf953f0"
+  resolved "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz"
   integrity sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==
   dependencies:
     "@types/node" "*"
@@ -2100,7 +2100,7 @@
 
 "@types/js-yaml@^4.0.9":
   version "4.0.9"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  resolved "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz"
   integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
 
 "@types/json-schema@^7.0.12", "@types/json-schema@^7.0.15":
@@ -2427,7 +2427,7 @@ ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
 
 ansis@^3.17.0, ansis@^3.2.0, ansis@^3.3.2:
   version "3.17.0"
-  resolved "https://registry.yarnpkg.com/ansis/-/ansis-3.17.0.tgz#fa8d9c2a93fe7d1177e0c17f9eeb562a58a832d7"
+  resolved "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz"
   integrity sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==
 
 anymatch@~3.1.2:
@@ -2609,7 +2609,7 @@ base64url@^3.0.1:
 
 better-sqlite3@^9:
   version "9.6.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-9.6.0.tgz#b01e58ba7c48abcdc0383b8301206ee2ab81d271"
+  resolved "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz"
   integrity sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==
   dependencies:
     bindings "^1.5.0"
@@ -2622,14 +2622,14 @@ binary-extensions@^2.0.0:
 
 bindings@^1.5.0:
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
 
 bl@^4.0.3:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  resolved "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
   dependencies:
     buffer "^5.5.0"
@@ -2650,22 +2650,15 @@ brace-expansion@^1.1.7:
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz"
+  integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2, braces@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
-  dependencies:
-    fill-range "^7.0.1"
-
-braces@^3.0.3:
+braces@^3.0.2, braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
@@ -2697,7 +2690,7 @@ buffer-from@^1.0.0:
 
 buffer@^5.5.0:
   version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
   dependencies:
     base64-js "^1.3.1"
@@ -2888,7 +2881,7 @@ chokidar@3.5.3, chokidar@^3.5.3:
 
 chownr@^1.1.1:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 ci-info@^4.0.0:
@@ -3153,15 +3146,10 @@ csstype@^3.0.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-csv-parse@^5:
+csv-parse@^5, csv-parse@^5.5.2:
   version "5.6.0"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.6.0.tgz#219beace2a3e9f28929999d2aa417d3fb3071c7f"
+  resolved "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz"
   integrity sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==
-
-csv-parse@^5.5.2:
-  version "5.5.5"
-  resolved "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.5.tgz"
-  integrity sha512-erCk7tyU3yLWAhk6wvKxnyPtftuy/6Ak622gOO7BCJ05+TYffnPCJF905wmOQm+BpkX54OdAl8pveJwUdpnCXQ==
 
 csv-stringify@^6.4.4:
   version "6.4.6"
@@ -3233,7 +3221,7 @@ deep-eql@^4.1.3:
 
 deep-extend@^0.6.0:
   version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3:
@@ -3283,7 +3271,7 @@ detect-indent@^7.0.1:
 
 detect-libc@^2.0.0:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 detect-newline@^4.0.0:
@@ -3411,17 +3399,10 @@ emoji-regex@^9.2.2:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
-
-end-of-stream@^1.4.1:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
-  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
   dependencies:
     once "^1.4.0"
 
@@ -3799,7 +3780,7 @@ execa@^5.0.0:
 
 expand-template@^2.0.3:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  resolved "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
 extend@^3.0.2:
@@ -3817,20 +3798,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0:
-  version "3.3.2"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz"
-  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
-fast-glob@^3.3.3:
+fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.3:
   version "3.3.3"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
@@ -3918,7 +3888,7 @@ file-entry-cache@^6.0.1:
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filelist@^1.0.1:
@@ -3928,16 +3898,9 @@ filelist@^1.0.1:
   dependencies:
     minimatch "^5.0.1"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
-  dependencies:
-    to-regex-range "^5.0.1"
-
 fill-range@^7.1.1:
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz"
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
@@ -4037,7 +4000,7 @@ fromentries@^1.2.0:
 
 fs-constants@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  resolved "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-extra@^11.0.0:
@@ -4065,7 +4028,7 @@ fs.realpath@^1.0.0:
 
 fsevents@~2.3.2:
   version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
@@ -4176,7 +4139,7 @@ git-raw-commits@^2.0.11:
 
 github-from-package@0.0.0:
   version "0.0.0"
-  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  resolved "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
   integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 github-slugger@^2:
@@ -4283,7 +4246,7 @@ globby@^13.1.2:
 
 globby@^14.1.0:
   version "14.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-14.1.0.tgz#138b78e77cf5a8d794e327b15dce80bf1fb0a73e"
+  resolved "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz"
   integrity sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==
   dependencies:
     "@sindresorhus/merge-streams" "^2.1.0"
@@ -4511,7 +4474,7 @@ ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.0:
 
 ignore@^7.0.3:
   version "7.0.5"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
 immediate@~3.0.5:
@@ -4938,7 +4901,7 @@ joycon@^3.1.1:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@^4.1.0:
+js-yaml@4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -4953,9 +4916,9 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.1:
+js-yaml@^4.1.0, js-yaml@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
@@ -5400,17 +5363,9 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.2, micromatch@^4.0.4:
-  version "4.0.5"
-  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
-  dependencies:
-    braces "^3.0.2"
-    picomatch "^2.3.1"
-
-micromatch@^4.0.8:
+micromatch@^4.0.2, micromatch@^4.0.8:
   version "4.0.8"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
     braces "^3.0.3"
@@ -5509,7 +5464,7 @@ minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
 
 mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  resolved "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mocha@^10.4.0:
@@ -5568,7 +5523,7 @@ mute-stream@^1.0.0:
 
 napi-build-utils@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-2.0.0.tgz#13c22c0187fcfccce1461844136372a47ddc027e"
+  resolved "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz"
   integrity sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==
 
 natural-compare@^1.4.0:
@@ -5613,7 +5568,7 @@ no-case@^3.0.4:
 
 node-abi@^3.3.0:
   version "3.87.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.87.0.tgz#423e28fea5c2f195fddd98acded9938c001ae6dd"
+  resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz"
   integrity sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==
   dependencies:
     semver "^7.3.5"
@@ -5991,7 +5946,7 @@ path-type@^4.0.0:
 
 path-type@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-6.0.0.tgz#2f1bb6791a91ce99194caede5d6c5920ed81eb51"
+  resolved "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz"
   integrity sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==
 
 pathval@^1.1.1:
@@ -6127,7 +6082,7 @@ pluralize@^8.0.0:
 
 prebuild-install@^7.1.1:
   version "7.1.3"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.3.tgz#d630abad2b147443f20a212917beae68b8092eec"
+  resolved "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz"
   integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
   dependencies:
     detect-libc "^2.0.0"
@@ -6254,7 +6209,7 @@ randombytes@^2.1.0:
 
 rc@^1.2.7:
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  resolved "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
   dependencies:
     deep-extend "^0.6.0"
@@ -6549,7 +6504,7 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
 
 semver@^7.0.0, semver@^7.3.4, semver@^7.3.5, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.6.3, semver@^7.7.4:
   version "7.7.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 sentence-case@^3.0.4:
@@ -6659,12 +6614,12 @@ signal-exit@^4.0.1, signal-exit@^4.1.0:
 
 simple-concat@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  resolved "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
 simple-get@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  resolved "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz"
   integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
   dependencies:
     decompress-response "^6.0.0"
@@ -6855,7 +6810,16 @@ stack-utils@^2.0.6:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6909,21 +6873,28 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-string_decoder@^1.1.1, string_decoder@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@~1.1.1:
+string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6966,7 +6937,7 @@ strip-json-comments@3.1.1, strip-json-comments@^3.1.1:
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
 strnum@^1.0.5:
@@ -7010,7 +6981,7 @@ supports-preserve-symlinks-flag@^1.0.0:
 
 tar-fs@^2.0.0:
   version "2.1.4"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.4.tgz#800824dbf4ef06ded9afea4acafe71c67c76b930"
+  resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz"
   integrity sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==
   dependencies:
     chownr "^1.1.1"
@@ -7020,7 +6991,7 @@ tar-fs@^2.0.0:
 
 tar-stream@^2.1.4:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz"
   integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
   dependencies:
     bl "^4.0.3"
@@ -7318,7 +7289,7 @@ undici-types@~6.19.8:
 
 unicorn-magic@^0.3.0:
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.3.0.tgz#4efd45c85a69e0dd576d25532fbfa22aa5c8a104"
+  resolved "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz"
   integrity sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==
 
 universalify@^0.1.0:
@@ -7514,7 +7485,7 @@ workerpool@6.2.1:
   resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7527,6 +7498,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -7603,7 +7583,7 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@20.2.4:
+yargs-parser@20.2.4, yargs-parser@^20.2.2:
   version "20.2.4"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
@@ -7616,7 +7596,7 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.3:
+yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==


### PR DESCRIPTION
   - Add `bulkyard schema` command for caching Salesforce object schemas into a local SQLite database
   - Add core utilities for SOQL `SELECT *` expansion, object metadata management, and schema cache interaction
   - Add tests for schema management, `SELECT *` functionality, and database integration